### PR TITLE
Fix a problem if the file system is case-sensitive

### DIFF
--- a/latex.dict.yaml
+++ b/latex.dict.yaml
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 ---
-name: LaTeX
+name: latex
 version: "0.2"
 sort: original
 columns:


### PR DESCRIPTION
I failed to load the file under Linux with log
```
E0612 17:25:46.271083 14522 dict_compiler.cc:65] source file '***/.config/ibus/rime/LaTeX.dict.yaml' does not exist.
E0612 17:25:46.271086 14522 deployment_tasks.cc:367] dictionary 'latex' failed to compile.
```
which indicates that there is an issue about the case of the filename. I fixed this by modifying the name here.