### PR TITLE
add configuration guide to use with other schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ patch:
     - punct_translator
     - r10n_translator
     - reverse_lookup_translator
-  recognizer/patterns/reverse_lookup: '^\\\D+$' # '.*'
+  recognizer/patterns/reverse_lookup: '\D+'
   schema/dependencies:
     - latex
   abc_segmentor/extra_tags:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # RIME_LaTeX
+
 Difficulty typing mathematical symbols?
 
 Try Rime-latex for Latex-based Symbols:)
@@ -6,6 +7,7 @@ Try Rime-latex for Latex-based Symbols:)
 ## RIME_LaTeX's extension to tex symbols
 
 ### Number superscript/subscript
+
 `^1` and `_1` to type over\under position numbers to type `¹₁`, 
 ```
 X₁¹ <- ^1 _1 
@@ -21,14 +23,37 @@ X₁¹ <- ^1 _1
 ⇛ \TO
 ```
 
-# Credits
+## Use with other schemas
+
+For instance, to use with 朙月拼音（·简化字）, in `luna_pinyin.custom.yaml` (`luna_pinyin_simp.custom.yaml`)
+
+```yaml
+patch:
+  engine/translators:
+    - punct_translator
+    - r10n_translator
+    - reverse_lookup_translator
+  recognizer/patterns/reverse_lookup: '^\\\D+$' # '.*'
+  schema/dependencies:
+    - latex
+  abc_segmentor/extra_tags:
+    - reverse_lookup
+  reverse_lookup:
+    dictionary: latex
+    enable_completion: false
+    tips: latex
+```
+
+The configuration above allows only latex symbols start with '\\' and without any digits to avoid conflicts.
+
+## Credits
 
 The latex math symbols table sources:
 
 https://github.com/hubutui/fcitx-table-unicode-latex
 https://github.com/moebiuscurve/ibus-table-others/blob/master/tables/latex.txt
 
-# Plans
+## Plans
 
 + Sanitize the more.
   + The symbols table should only contains those which are in both unicode & Latex
@@ -36,7 +61,3 @@ https://github.com/moebiuscurve/ibus-table-others/blob/master/tables/latex.txt
   + Unicode <https://en.wikipedia.org/wiki/Mathematical_operators_and_symbols_in_Unicode>
 
 + Fuzzy match?
-
-# TODO：
-
-+ 写一个关于如何配合其它输入法的说明。

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ patch:
     tips: latex
 ```
 
-The configuration above allows only latex symbols start with '\\' and without any digits to avoid conflicts.
+The configuration above allows only latex symbols without any digits to avoid conflicts.
 
 ## Credits
 

--- a/latex.schema.yaml
+++ b/latex.schema.yaml
@@ -12,7 +12,7 @@ schema:
     Latex Math Symbols Input Method.
     This schema is intended to be used as an addon for other input methods.
 
-engine: 
+engine:
   processors:
     - speller  # to enable alphabet & initials below.
     - selector

--- a/latex.schema.yaml
+++ b/latex.schema.yaml
@@ -4,19 +4,15 @@
 schema:
   schema_id: latex
   name: Latex Math Symbols
-  version: '1.0'
+  version: "1.1"
   author:
     - slbtty <shenlebantongying@gmail.com>
+    - mark <mark@mkmark.net>
   description: |
     Latex Math Symbols Input Method.
-    
-    You have to type '\' first to get symbols.
-    
     This schema is intended to be used as an addon for other input methods.
-    
-  dependencies:
 
-engine:
+engine: 
   processors:
     - speller  # to enable alphabet & initials below.
     - selector


### PR DESCRIPTION
fix #9

some obstacles:
entries with digits (i.e. `^0`, `_1`) still can not be properly merged with other schemas due to conflict with result selection by number; `^` and `_`, or `\^` and `\_` can not be properly configured.

reverse_lookup regex has the following effects:
- `.*`: can use any entries but result selection with numbers will be disabled
- `^\W\D+$` or sth like `^[\\^_]\D+$`: should work with `^` and `_` but actually has no effect

I also tried to modify the table definition such as to replace `^0` with `\^0` but without success. It will result in errors in other entries' lookup and make the latex dictionary completely unusable. (This only happens when using with other schemas though.)

So the current version uses  `^\\\D+$` to match only `\`
