### PR TITLE
fix prism

### DIFF
--- a/latex.schema.yaml
+++ b/latex.schema.yaml
@@ -31,6 +31,5 @@ speller:
 
 translator:
   dictionary: latex
-  prism: latex_symbols
   enable_sentence: false
   enable_user_dict: false


### PR DESCRIPTION
This PR fixes a problem that would cause latex schema not to work within other schemas.
Since `reverse_lookup` does not seem to allow custom prism, [this line](https://github.com/shenlebantongying/rime_latex/blob/f66a7c708e47b03ebf330cc840703fc8a55ea1cb/latex.schema.yaml#L34) will cause `latex.prism.bin` not generated and thus cannot be found when using with other schemas.

It could be a coincidence that @shenlebantongying and I can use the previous version without problems, that `latex.prism.bin` must be somehow generated by other means. If you delete this file and then redeploy Rime, this file would be missing and thus cause misfunctions.

This is also the reason I got misfunction when modifying the dictionary during #14, which would be important in fixing some other issues.