### PR TITLE
Add more symbols

### DIFF
--- a/latex.dict.yaml
+++ b/latex.dict.yaml
@@ -435,7 +435,9 @@ $	\dollar
 ≢	\nequiv
 ≣	\Equiv
 ≤	\leq
+≤	\le
 ≥	\geq
+≥	\ge
 ≦	\leqq
 ≧	\geqq
 ≨	\lneqq

--- a/latex.dict.yaml
+++ b/latex.dict.yaml
@@ -225,6 +225,7 @@ $	\dollar
 ⅋	\upand
 ←	\<-
 ←	\leftarrow
+←	\gets
 ↑	\uparrow
 →	\->
 →	\to


### PR DESCRIPTION
In LaTeX, both `\le` and `\leq` will be displayed as the same symbol `≤`, and `\ge` is the same.