### PR TITLE
<docs> <README.md>: use latex with other schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,45 @@ For instance, to use with 朙月拼音（·简化字）, in `luna_pinyin.custom.
 
 ```yaml
 patch:
+# type '\' will pull in English punctuation, so need to switch to Chinese punctuation
+  switches/+:
+    - name: ascii_punct # 
+      states: [ ¥, $ ]
+      reset: 0
+# make '\' go into the candidate box
+  speller/alphabet: zyxwvutsrqponmlkjihgfedcba\\
+# or customize punctuator to make '\' go into the candidate box like below(please uncomment yourself)
+#  punctuator/half_shape:
+#    "\\": ["\\"]
+#  punctuator/full_shape:
+#    "\\": ["、", "＼"]
+
   engine/translators:
     - punct_translator
-    - r10n_translator
-    - reverse_lookup_translator
-# meaning of the regex: ^ start of line, \\ the starting \, .+ any char 1 or more time, $ end 
-  recognizer/patterns/reverse_lookup: '^\\.+$'
-  schema/dependencies:
+    - table_translator
+    - table_translator@latex_input
+# meaning of the regex: ^ (start of line), \\(the starting \), .+(any char 1 or more time), $(end)
+# first '\\' is recognized as a symbol(half_shape or full_shape). double '\\' make it to be recognized as a pattern
+# translator's prefix will consume one '\\'. so user only type once '\' key
+  "recognizer/patterns/latex_input": "^\\\\.+$"
+  schema/dependencies/+:
     - latex
-  abc_segmentor/extra_tags:
-    - reverse_lookup
-  reverse_lookup:
+  latex_input:
+    tag: latex_input
     dictionary: latex
-    enable_completion: false
-    tips: latex
+    prefix: "\\"
+    enable_sentence: false
+    enable_completion: true # enable autocomplete
+    enable_user_dict: true # enable word frequency,  use with user_dict
+    user_dict: custom_latex_user # generate a file name custom_latex_user.txt
+    db_class: tabledb
+    tips: "[LaTex]"
 ```
 
 ## RIME_LaTeX's extension to tex symbols
 
 ### superscript/subscript
-
+user type once '\' key and input latex with autocomplete prompt
 ```
 \^1 \_1 -> X₁¹
 \^a \_b -> Xᵃᵦ
@@ -56,6 +75,9 @@ The latex math symbols table sources:
 
 https://github.com/hubutui/fcitx-table-unicode-latex
 https://github.com/moebiuscurve/ibus-table-others/blob/master/tables/latex.txt
+
+Rime schema description:
+https://github.com/LEOYoon-Tsaw/Rime_collections/blob/master/Rime_description.md
 
 ## Plans
 


### PR DESCRIPTION
1. modify the instance of use latex with other schema
2. make '\' go into the candidate box and recognize
3. replace r10n_translator with table_translator
4. enable autocomplete and word frequency
5. add Rime schema description references 
<footer>: Close #19